### PR TITLE
Update checkout action version to avoid build warnning message.

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -9,7 +9,7 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         # with:
           # BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Modify checkout actions to run on Node 20 instead of Node 16. 
[https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/](url)